### PR TITLE
Send pca to device

### DIFF
--- a/src/torch_pca/pca_main.py
+++ b/src/torch_pca/pca_main.py
@@ -396,3 +396,24 @@ class PCA:
         self._check_fitted("_n_features_out")
         assert self.components_ is not None  # for mypy
         return self.components_.shape[0]
+
+    def to(self, device: str) -> None:
+        """Sends the tensors of a fitted PCA to the specified device.
+
+        Parameters
+        ----------
+        device : str
+            a valid torch device
+        """
+        if self.components_ is not None:
+            self.components_.to(device)
+        if self.explained_variance_ is not None:
+            self.explained_variance_.to(device)
+        if self.explained_variance_ratio_ is not None:
+            self.explained_variance_ratio_.to(device)
+        if self.mean_ is not None:
+            self.mean_.to(device)
+        if self.noise_variance_ is not None:
+            self.noise_variance_.to(device)
+        if self.singular_values_ is not None:
+            self.singular_values_.to(device)

--- a/src/torch_pca/pca_main.py
+++ b/src/torch_pca/pca_main.py
@@ -396,3 +396,24 @@ class PCA:
         self._check_fitted("_n_features_out")
         assert self.components_ is not None  # for mypy
         return self.components_.shape[0]
+
+    def to(self, device: str) -> None:
+        """Sends the tensors of a fitted PCA to the specified device.
+
+        Parameters
+        ----------
+        device : str
+            a valid torch device
+        """
+        if self.components_ is not None:
+            self.components_ = self.components_.to(device)
+        if self.explained_variance_ is not None:
+            self.explained_variance_ = self.explained_variance_.to(device)
+        if self.explained_variance_ratio_ is not None:
+            self.explained_variance_ratio_ = self.explained_variance_ratio_.to(device)
+        if self.mean_ is not None:
+            self.mean_ = self.mean_.to(device)
+        if self.noise_variance_ is not None:
+            self.noise_variance_ = self.noise_variance_.to(device)
+        if self.singular_values_ is not None:
+            self.singular_values_ =  self.singular_values_.to(device)


### PR DESCRIPTION
The goal of this pull request is to implement a feature that allows for a PCA to be sent to a device like a torch.nn.Module.

It allows the user to cal PCA.to(device) where device is a string similar to a torch device.
It then moves each tensor in the PCA object to the given device.