### PR TITLE
Add inverse whitening to inverse_transform

### DIFF
--- a/src/torch_pca/pca_main.py
+++ b/src/torch_pca/pca_main.py
@@ -319,7 +319,11 @@ class PCA:
         """
         self._check_fitted("inverse_transform")
         assert self.components_ is not None  # for mypy
-        de_transformed = inputs @ self.components_ + self.mean_
+        if self.whiten:
+            scaled_components = torch.sqrt(self.explained_variance_) * self.components_
+            de_transformed = inputs @ scaled_components + self.mean_
+        else:
+            de_transformed = inputs @ self.components_ + self.mean_
         return de_transformed
 
     def get_covariance(self) -> Tensor:


### PR DESCRIPTION
"whiten" option is handled in [transform] but not in [inverse_transform] method :bug: 
This PR is to add "inverse_whiten" to the [inverse_transform] method.

https://github.com/scikit-learn/scikit-learn/blob/4a10d0ed8d85e6ed24a647bd28a65c0c64b101ef/sklearn/decomposition/_base.py#L200